### PR TITLE
Add more integer conversions

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -278,8 +278,10 @@ PYBIND11_TYPE_CASTER_NUMBER(int32_t, long, PyLong_AsLong, PyLong_FromLong)
 PYBIND11_TYPE_CASTER_NUMBER(uint32_t, unsigned long, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong)
 PYBIND11_TYPE_CASTER_NUMBER(int64_t, PY_LONG_LONG, PyLong_AsLongLong_Fixed, PyLong_FromLongLong)
 PYBIND11_TYPE_CASTER_NUMBER(uint64_t, unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong_Fixed, PyLong_FromUnsignedLongLong)
+#ifdef __linux__
 PYBIND11_TYPE_CASTER_NUMBER(long long, PY_LONG_LONG, PyLong_AsLongLong_Fixed, PyLong_FromLongLong)
 PYBIND11_TYPE_CASTER_NUMBER(unsigned long long, unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong_Fixed, PyLong_FromUnsignedLongLong)
+#endif
 
 #if defined(__APPLE__) // size_t/ssize_t are separate types on Mac OS X
 #if PY_MAJOR_VERSION >= 3

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -278,6 +278,8 @@ PYBIND11_TYPE_CASTER_NUMBER(int32_t, long, PyLong_AsLong, PyLong_FromLong)
 PYBIND11_TYPE_CASTER_NUMBER(uint32_t, unsigned long, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong)
 PYBIND11_TYPE_CASTER_NUMBER(int64_t, PY_LONG_LONG, PyLong_AsLongLong_Fixed, PyLong_FromLongLong)
 PYBIND11_TYPE_CASTER_NUMBER(uint64_t, unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong_Fixed, PyLong_FromUnsignedLongLong)
+PYBIND11_TYPE_CASTER_NUMBER(long long, PY_LONG_LONG, PyLong_AsLongLong_Fixed, PyLong_FromLongLong)
+PYBIND11_TYPE_CASTER_NUMBER(unsigned long long, unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong_Fixed, PyLong_FromUnsignedLongLong)
 
 #if defined(__APPLE__) // size_t/ssize_t are separate types on Mac OS X
 #if PY_MAJOR_VERSION >= 3

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -253,6 +253,9 @@ public:
 #if !(defined(WIN32) || defined(__i386__)) || defined(_WIN64)
     int_(ssize_t value) : object(PyLong_FromSsize_t(value), false) { }
 #endif
+    int_(unsigned value) : object(PyLong_FromUnsignedLong((unsigned long) value), false) { }
+    int_(long long value) : object(PyLong_FromLongLong(value), false) { }
+    int_(unsigned long long value) : object(PyLong_FromUnsignedLongLong(value), false) { }
     operator int() const { return (int) PyLong_AsLong(m_ptr); }
 };
 


### PR DESCRIPTION
Without the changes in `cast.h`, on Linux, I'm unable to return `unsigned long long` from a function (works on Mac). Without the changes to `int_` (at least the constructor from `unsigned`), I cannot do things like `py::int_((uint32_t) 1)`.