### PR TITLE
Change non-ASCII characters to ASCII

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ traditional extension modules by inferring type information using compile-time
 introspection.
 
 The main issue with Boost.Python-and the reason for creating such a similar
-project—is Boost. Boost is an enormously large and complex suite of utility
+project-is Boost. Boost is an enormously large and complex suite of utility
 libraries that works with almost every C++ compiler in existence. This
 compatibility has its cost: arcane template tricks and workarounds are
 necessary to support the oldest and buggiest of compiler specimens. Now that

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ Boost.Python library by David Abrahams: to minimize boilerplate code in
 traditional extension modules by inferring type information using compile-time
 introspection.
 
-The main issue with Boost.Python—and the reason for creating such a similar
+The main issue with Boost.Python-and the reason for creating such a similar
 project—is Boost. Boost is an enormously large and complex suite of utility
 libraries that works with almost every C++ compiler in existence. This
 compatibility has its cost: arcane template tricks and workarounds are


### PR DESCRIPTION
As these are simply dashes, it seems reasonable to make them ASCII accepted. It also avoids some annoying python 2 encoding issues during build/install.