### PR TITLE
Add ldflags to compile command

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -117,7 +117,7 @@ example can be compiled using the following command
 
 .. code-block:: bash
 
-    $ c++ -O3 -shared -std=c++11 -I <path-to-pybind11>/include `python-config --cflags --libs` example.cpp -o example.so
+    $ c++ -O3 -shared -std=c++11 -I <path-to-pybind11>/include `python-config --cflags --ldflags --libs` example.cpp -o example.so
 
 In general, it is advisable to include several additional build parameters
 that can considerably reduce the size of the created binary. Refer to section


### PR DESCRIPTION
On my system (Mac OS with custom Python installation) I had to add the ldflags argument to python-config to get things working.