### PR TITLE
Add complex.h to list of installed headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(PYBIND11_HEADERS
   include/pybind11/pytypes.h
   include/pybind11/typeid.h
   include/pybind11/numpy.h
+  include/pybind11/complex.h
 )
 
 # Create the binding library


### PR DESCRIPTION
When installing the headers with `make install` the file `pybind11/complex.h` is not installed. This goes unnoticed since `numpy.h` just contains

```c++
#include <complex.h>
```

which will usually succeed because there is a C-header with that name installed in many systems but will cause failures when trying to use complex arrays.

Fixed by adding `complex.h` to `PYBIND11_HEADERS` in cmake lists.

I've noticed the same is true for `stl.h`, should that possibly be added as well?