### PR TITLE
Fixed py:array constructor from failing for complex types

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -96,7 +96,7 @@ public:
 
     array(const buffer_info &info) {
         API& api = lookup_api();
-        if (info.format.size() != 1)
+        if ((info.format.size() < 1) || (info.format.size() > 2))
             throw std::runtime_error("Unsupported buffer format!");
         int fmt = (int) info.format[0];
         if (info.format == "Zd")


### PR DESCRIPTION
The `array(const buffer_info &info)` constructor fails when given
complex types since their format string is `Zd` or `Zf` which has
a length of two and causes an error here:

```c++
if (info.format.size() != 1)
    throw std::runtime_error("Unsupported buffer format!");
```

Fixed by allowing format sizes of one and two.