### PR TITLE
Fix crash when calling buffer.request multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cmake_install.cmake
 .DS_Store
 /example/example.so
 /example/example.pyd
+/build/*
 *.sln
 *.sdf
 *.opensdf

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -423,20 +423,21 @@ public:
     buffer_info request(bool writable = false) {
         int flags = PyBUF_STRIDES | PyBUF_FORMAT;
         if (writable) flags |= PyBUF_WRITABLE;
-        view = new Py_buffer();
-        if (PyObject_GetBuffer(m_ptr, view, flags) != 0)
+        Py_buffer view;
+        if (PyObject_GetBuffer(m_ptr, &view, flags) != 0)
             throw error_already_set();
-        std::vector<size_t> shape(view->ndim), strides(view->ndim);
-        for (int i=0; i<view->ndim; ++i) {
-            shape[i] = (size_t) view->shape[i];
-            strides[i] = (size_t) view->strides[i];
+        std::vector<size_t> shape(view.ndim), strides(view.ndim);
+        for (int i = 0; i < view.ndim; ++i) {
+            shape[i] = (size_t)view.shape[i];
+            strides[i] = (size_t)view.strides[i];
         }
-        return buffer_info(view->buf, view->itemsize, view->format,
-                           view->ndim, shape, strides);
+        buffer_info result(view.buf, view.itemsize, view.format,
+                           view.ndim, shape, strides);
+
+        PyBuffer_Release(&view);
+
+        return result;
     }
-    ~buffer() { if (view) { PyBuffer_Release(view); delete view; } }
-private:
-    Py_buffer *view = nullptr;
 };
 
 NAMESPACE_BEGIN(detail)


### PR DESCRIPTION
buffer.request now creates a temporary Py_buffer instead of a pointer.
This reduces the probability of misstakes, and stops a segfault when
buffer.request was called twice.

I think the new design has no major drawbacks over the previous, it is possibly faster since the buffer is now stack-allocated. Also we got rid of the destructor which should not be needed in this case.

Also add build folder to gitignore.