### PR TITLE
Avoid losing null-chars when casting to/from std::string.

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -378,15 +378,15 @@ public:
 #endif
 };
 
-template <> class type_caster<bytestring> : public type_caster<std::string> {
+template <typename T> class type_caster<bytes<T>> : public type_caster<T> {
 public:
-    static PyObject *cast(const bytestring &src, return_value_policy /* policy */, PyObject * /* parent */) {
-        return PYBIND11_FROM_STRING_AND_SIZE(src.c_str(), src.size());
+    static PyObject *cast(const bytes<T> &src, return_value_policy /* policy */, PyObject * /* parent */) {
+        return PYBIND11_FROM_STRING_AND_SIZE(src.data(), src.size());
     }
 #if PY_MAJOR_VERSION >= 3
-    PYBIND11_TYPE_CASTER(bytestring, "bytes");
+    PYBIND11_TYPE_CASTER(bytes<T>, "bytes");
 #else
-    PYBIND11_TYPE_CASTER(bytestring, "str");
+    PYBIND11_TYPE_CASTER(bytes<T>, "str");
 #endif
 };
 

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -423,13 +423,6 @@ protected:
     std::string value;
 };
 
-template <> class type_caster<bytepchar> : public type_caster<char> {
-public:
-    static PyObject *cast(const bytepchar src, return_value_policy /* policy */, PyObject * /* parent */) {
-        return PYBIND11_FROM_STRING(src);
-    }
-};
-
 template <typename T1, typename T2> class type_caster<std::pair<T1, T2>> {
     typedef std::pair<T1, T2> type;
 public:

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -259,13 +259,14 @@ inline iterator handle::end() { return iterator(nullptr); }
     PYBIND11_OBJECT(Name, Parent, CheckFun) \
     Name() : Parent() { }
 
-class bytestring : public std::string {
+template <typename T>
+class bytes : public T {
 public:
-    using std::string::string;
+    using T::T;
 
-    bytestring(const std::string& src) : std::string(src) { }
-    bytestring(std::string&& src) : std::string(std::move(src)) { }
-    bytestring() : std::string() { }
+    bytes(const T& src) : T(src) { }
+    bytes(T&& src) : T(std::move(src)) { }
+    bytes() : T() { }
 };
 
 class str : public object {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -263,8 +263,9 @@ class bytestring : public std::string {
 public:
     using std::string::string;
 
-    bytestring(const std::string& src) : std::string(src) {}
-    bytestring() : std::string() {}
+    bytestring(const std::string& src) : std::string(src) { }
+    bytestring(std::string&& src) : std::string(std::move(src)) { }
+    bytestring() : std::string() { }
 };
 
 class str : public object {

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -267,16 +267,6 @@ public:
     bytestring() : std::string() {}
 };
 
-class bytepchar {
-public:
-    bytepchar(const char* src) : ptr(const_cast<char*>(src)) {}
-    operator const char*() const {
-        return ptr;
-    }
-private:
-    char* ptr;
-};
-
 class str : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(str, object, PyUnicode_Check)

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -259,6 +259,24 @@ inline iterator handle::end() { return iterator(nullptr); }
     PYBIND11_OBJECT(Name, Parent, CheckFun) \
     Name() : Parent() { }
 
+class bytestring : public std::string {
+public:
+    using std::string::string;
+
+    bytestring(const std::string& src) : std::string(src) {}
+    bytestring() : std::string() {}
+};
+
+class bytepchar {
+public:
+    bytepchar(const char* src) : ptr(const_cast<char*>(src)) {}
+    operator const char*() const {
+        return ptr;
+    }
+private:
+    char* ptr;
+};
+
 class str : public object {
 public:
     PYBIND11_OBJECT_DEFAULT(str, object, PyUnicode_Check)


### PR DESCRIPTION
In Python, strings ofter carry binary data including NULL characters, we should try to avoid losing them when calling C++ functions, std::string can hold NULL char easily.

This PR changes casts to use *_AsStringAndSize functions, which copy full string length.

I kept unicode->utf8 in Python to C++ casts (since we have PyUnicode_Check).

Unfortunately in C++ to Python cast there is no way to know if byte sequence is intended to be utf8 string, so for consistency and to avoid data loss we should return str/bytes and do decoding on the Python side. (Maybe one can introduce a helper class py::utf8string which can indicate the API intent to decode utf8 string).

Python 2:
str -> std::string
unicode (utf8) -> std::string
std::string -> str

Python 3:
bytes -> std::string
str (utf8) -> std::string
std::string -> bytes