### PR TITLE
Add const modifier to handle::cast.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -118,7 +118,7 @@ Without reference counting
     Return a string representation of the object. This is analogous to
     the ``str()`` function in Python.
 
-.. function:: template <typename T> T handle::cast()
+.. function:: template <typename T> T handle::cast() const
 
     Attempt to cast the Python object into the given C++ type. A
     :class:`cast_error` will be throw upon failure.

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -594,8 +594,8 @@ template <typename T> inline object cast(const T &value, return_value_policy pol
     return object(detail::type_caster<typename detail::decay<T>::type>::cast(value, policy, parent), false);
 }
 
-template <typename T> inline T handle::cast() { return pybind11::cast<T>(m_ptr); }
-template <> inline void handle::cast() { return; }
+template <typename T> inline T handle::cast() const { return pybind11::cast<T>(m_ptr); }
+template <> inline void handle::cast() const { return; }
 
 template <typename... Args> inline object handle::call(Args&&... args_) {
     const size_t size = sizeof...(Args);

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -42,7 +42,7 @@ public:
     inline detail::accessor attr(handle key);
     inline detail::accessor attr(const char *key);
     inline pybind11::str str() const;
-    template <typename T> T cast();
+    template <typename T> T cast() const;
     template <typename ... Args> object call(Args&&... args_);
     operator bool() const { return m_ptr != nullptr; }
     bool check() const { return m_ptr != nullptr; }


### PR DESCRIPTION
The cast method of handle does not modify the instance in any way so it can safely be made const.
