### PR TITLE
Use object class to hold partially converted python objects.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -59,7 +59,7 @@ Without reference counting
 
     Creates a :class:`handle` from the given raw Python object pointer.
 
-.. function:: PyObject * handle::ptr()
+.. function:: PyObject * handle::ptr() const
 
     Return the ``PyObject *`` underlying a :class:`handle`.
 
@@ -166,6 +166,12 @@ With reference counting
 
     Move constructor; steals the object from ``other`` and preserves its
     reference count.
+
+.. function:: PyObject* object::release()
+
+    Release ownership of underlying ``PyObject *``. Returns raw Python object
+    pointer without decreasing its reference count and resets handle to
+    ``nullptr``-valued pointer.
 
 .. function:: object::~object()
 

--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -29,8 +29,7 @@ public:
     handle() : m_ptr(nullptr) { }
     handle(const handle &other) : m_ptr(other.m_ptr) { }
     handle(PyObject *ptr) : m_ptr(ptr) { }
-    PyObject *ptr() { return m_ptr; }
-    const PyObject *ptr() const { return m_ptr; }
+    PyObject *ptr() const { return m_ptr; }
     void inc_ref() const { Py_XINCREF(m_ptr); }
     void dec_ref() const { Py_XDECREF(m_ptr); }
     int ref_count() const { return (int) Py_REFCNT(m_ptr); }
@@ -59,6 +58,12 @@ public:
     object(PyObject *ptr, bool borrowed) : handle(ptr) { if (borrowed) inc_ref(); }
     object(object &&other) { m_ptr = other.m_ptr; other.m_ptr = nullptr; }
     ~object() { dec_ref(); }
+
+    PyObject * release() {
+      PyObject *tmp = m_ptr;
+      m_ptr = nullptr;
+      return tmp;
+    }
 
     object& operator=(object &other) {
         Py_XINCREF(other.m_ptr);


### PR DESCRIPTION
Using object class to hold converted object automatically deallocates
object if an exception is thrown or scope is left before constructing
complete Python object.

Additionally added method object::release() that allows to release
ownership of python object without decreasing its reference count.

This addresses the issue #55.