### PR TITLE
Fix Compile Error: str Naming

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -284,12 +284,12 @@ private:
 };
 
 inline pybind11::str handle::str() const {
-    PyObject *str = PyObject_Str(m_ptr);
+    PyObject *myStr = PyObject_Str(m_ptr);
 #if PY_MAJOR_VERSION < 3
-    PyObject *unicode = PyUnicode_FromEncodedObject(str, "utf-8", nullptr);
-    Py_XDECREF(str); str = unicode;
+    PyObject *unicode = PyUnicode_FromEncodedObject(myStr, "utf-8", nullptr);
+    Py_XDECREF(myStr); myStr = unicode;
 #endif
-    return pybind11::str(str, false);
+    return pybind11::str(myStr, false);
 }
 
 class bool_ : public object {


### PR DESCRIPTION
This fixes a build error compiling with `nvcc/7.5` and `gcc/4.9.2` causing a
```
./include/pybind11/pytypes.h: In member function ‘pybind11::str pybind11::handle::str() const’:
./include/pybind11/pytypes.h:292:8: error: expected primary-expression before ‘class’
     return pybind11::str(str, false);
        ^
./include/pybind11/pytypes.h:292:8: error: expected ‘;’ before ‘class’
./include/pybind11/pytypes.h:292:8: error: expected primary-expression before ‘class’
```

I guess there are just some namings of the var `str` and the type `str` and the function name `str` colliding.