### PR TITLE
Tell cmake to use EXACT python version (from PYBIND11_PYTHON_VERSION).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
-find_package(PythonLibs ${PYBIND11_PYTHON_VERSION} EXACT REQUIRED)
-find_package(PythonInterp ${PYBIND11_PYTHON_VERSION} EXACT REQUIRED)
+find_package(PythonLibs ${PYBIND11_PYTHON_VERSION} REQUIRED)
+find_package(PythonInterp ${PYBIND11_PYTHON_VERSION} REQUIRED)
 
 include(CheckCXXCompilerFlag)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
-find_package(PythonLibs ${PYBIND11_PYTHON_VERSION} REQUIRED)
-find_package(PythonInterp ${PYBIND11_PYTHON_VERSION} REQUIRED)
+find_package(PythonLibs ${PYBIND11_PYTHON_VERSION} EXACT REQUIRED)
+find_package(PythonInterp ${PYBIND11_PYTHON_VERSION} EXACT REQUIRED)
 
 include(CheckCXXCompilerFlag)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,9 @@ project(pybind11)
 
 option(PYBIND11_INSTALL "Install pybind11 header files?" ON)
 
-# Add a CMake parameter for choosing a desired Python version
-set(PYBIND11_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the example application")
+# To choose a different Python interpreter than the default one, set the
+# the PYTHON_LIBRARY and PYTHON_INCLUDE_DIR flag when calling cmake.
+# See https://cmake.org/cmake/help/v3.0/module/FindPythonLibs.html
 
 # Set a default build configuration if none is specified. 'MinSizeRel' produces the smallest binaries
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -24,8 +25,8 @@ endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
-find_package(PythonLibs ${PYBIND11_PYTHON_VERSION} REQUIRED)
-find_package(PythonInterp ${PYBIND11_PYTHON_VERSION} REQUIRED)
+find_package(PythonLibs REQUIRED)
+find_package(PythonInterp REQUIRED)
 
 include(CheckCXXCompilerFlag)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
 find_package(PythonLibs REQUIRED)
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp ${PYTHONLIBS_VERSION_STRING} EXACT REQUIRED)
 
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
This should insure that both the `PythonLibs` and `PythonInterp` points to
the same python version.

Without this, the Python library and interpreter might not match version.
For example, if both Python 2.7 and 3.4 is installed, `PythonLibs` will
find /usr/lib/x86_64-linux-gnu/libpython3.4m.so while
`PythonInterp` will find /usr/bin/python2.7 (at least on Ubuntu 14.04).

When `PythonLibs` and `PythonInterp` don't point to the same Python version,
the examples will all fail:

```bash
$ cmake ..
-- The C compiler identification is GNU 4.8.4
-- The CXX compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Setting build type to 'MinSizeRel' as none was specified.
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.4m.so (found suitable version "3.4.3", minimum required is "2.7")
-- Found PythonInterp: /usr/bin/python2.7 (found suitable version "2.7.6", minimum required is "2.7")
-- Performing Test HAS_LTO_FLAG
-- Performing Test HAS_LTO_FLAG - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /home/nbigaouette/pybind11/build
$ make test
Running tests...
Test project /home/nbigaouette/pybind11/build
      Start  1: example1
 1/12 Test  #1: example1 .........................***Failed    0.02 sec
      Start  2: example2
 2/12 Test  #2: example2 .........................***Failed    0.03 sec
      Start  3: example3
 3/12 Test  #3: example3 .........................***Failed    0.02 sec
      Start  4: example4
 4/12 Test  #4: example4 .........................***Failed    0.02 sec
      Start  5: example5
 5/12 Test  #5: example5 .........................***Failed    0.02 sec
      Start  6: example6
 6/12 Test  #6: example6 .........................***Failed    0.02 sec
      Start  7: example7
 7/12 Test  #7: example7 .........................***Failed    0.02 sec
      Start  8: example8
 8/12 Test  #8: example8 .........................***Failed    0.02 sec
      Start  9: example9
 9/12 Test  #9: example9 .........................***Failed    0.02 sec
      Start 10: example10
10/12 Test #10: example10 ........................***Failed    0.02 sec
      Start 11: example11
11/12 Test #11: example11 ........................***Failed    0.03 sec
      Start 12: example12
12/12 Test #12: example12 ........................***Failed    0.02 sec

0% tests passed, 12 tests failed out of 12

Total Test time (real) =   0.25 sec

The following tests FAILED:
          1 - example1 (Failed)
          2 - example2 (Failed)
          3 - example3 (Failed)
          4 - example4 (Failed)
          5 - example5 (Failed)
          6 - example6 (Failed)
          7 - example7 (Failed)
          8 - example8 (Failed)
          9 - example9 (Failed)
         10 - example10 (Failed)
         11 - example11 (Failed)
         12 - example12 (Failed)
Errors while running CTest
make: *** [test] Error 8
```

By adding the `EXACT` version to the `find_package()` calls, the version
discrepancy is at least caught at the cmake call:

```bash
$ cmake ..
-- The C compiler identification is GNU 4.8.4
-- The CXX compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Setting build type to 'MinSizeRel' as none was specified.
CMake Error at /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find PythonLibs: Found unsuitable version "3.4.3", but required
  is exact version "2.7" (found /usr/lib/x86_64-linux-gnu/libpython3.4m.so)
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:313 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-2.8/Modules/FindPythonLibs.cmake:208 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:27 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/nbigaouette/pybind11/build/CMakeFiles/CMakeOutput.log".
```