### PR TITLE
Fix Compile Error: str Naming

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -261,12 +261,12 @@ public:
 };
 
 inline pybind11::str handle::str() const {
-    PyObject *str = PyObject_Str(m_ptr);
+    PyObject *strValue = PyObject_Str(m_ptr);
 #if PY_MAJOR_VERSION < 3
-    PyObject *unicode = PyUnicode_FromEncodedObject(str, "utf-8", nullptr);
-    Py_XDECREF(str); str = unicode;
+    PyObject *unicode = PyUnicode_FromEncodedObject(strValue, "utf-8", nullptr);
+    Py_XDECREF(strValue); strValue = unicode;
 #endif
-    return pybind11::str(str, false);
+    return pybind11::str(strValue, false);
 }
 
 class bytes : public object {


### PR DESCRIPTION
Rebase and re-tested against `master` as of 48548ea4a5735acfb86c67354d3ea6a728169740, follow-up to #63: This fixes a build error compiling with `nvcc/7.5` + `gcc/4.9.2` causing a
```
./include/pybind11/pybind11.h(952): here

./include/pybind11/pytypes.h: In member function ‘pybind11::str pybind11::handle::str() const’:
./include/pybind11/pytypes.h:269:8: error: expected primary-expression before ‘class’
     return pybind11::str(str, false);
        ^
./include/pybind11/pytypes.h:269:8: error: expected ‘;’ before ‘class’
./include/pybind11/pytypes.h:269:8: error: expected primary-expression before ‘class’
```

Build command against a minimal example
```bash
# gcc: 4.9.2
# cuda: 7.5
# python: 2.7.6, 2.7.10, 3.4.3

# remove some doubled options & warnings from
#   `python[3]-config --cflags --ldflags --libs`
nvcc -shared -std=c++11 --compiler-options -fPIC \
  -I ./include/ -I/opt/pkg/devel/python/3.4.3/include/python3.4m \
  -I/opt/pkg/devel/python/3.4.3/include/python3.4m -DNDEBUG -g \
  -L/opt/pkg/devel/python/3.4.3/lib \
  -lpython3.4m -lpthread -ldl  -lutil -lm \
  -Xlinker -export-dynamic -lpython3.4m -lpthread -ldl -lutil -lm \
  mandelbrot.cu -o mandelbrot.so
```