### PR TITLE
Fix Compile Error: str Naming

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -261,12 +261,12 @@ public:
 };
 
 inline pybind11::str handle::str() const {
-    PyObject *str = PyObject_Str(m_ptr);
+    PyObject *strValue = PyObject_Str(m_ptr);
 #if PY_MAJOR_VERSION < 3
-    PyObject *unicode = PyUnicode_FromEncodedObject(str, "utf-8", nullptr);
-    Py_XDECREF(str); str = unicode;
+    PyObject *unicode = PyUnicode_FromEncodedObject(strValue, "utf-8", nullptr);
+    Py_XDECREF(strValue); strValue = unicode;
 #endif
-    return pybind11::str(str, false);
+    return pybind11::str(strValue, false);
 }
 
 class bytes : public object {


### PR DESCRIPTION
This fixes a build error compiling with `nvcc/7.5` + `gcc/4.9.2`
causing a
```
./include/pybind11/pybind11.h(952): here

./include/pybind11/pytypes.h: In member function ‘pybind11::str pybind11::handle::str() const’:
./include/pybind11/pytypes.h:269:8: error: expected primary-expression before ‘class’
     return pybind11::str(str, false);
        ^
./include/pybind11/pytypes.h:269:8: error: expected ‘;’ before ‘class’
./include/pybind11/pytypes.h:269:8: error: expected primary-expression before ‘class’
```