### PR TITLE
common.h: include <cmath> before <Python.h> on mingw

### DIFF
--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -44,6 +44,14 @@
 #  endif
 #endif
 
+// Pythons pyconfig.h #defines hypot to _hypot on windows + gnuc but the cmath from mingw expects it to be named hypot. We work around that by including cmath before python
+#if defined(__GNUC__) && defined(_WIN32) && defined(__MINGW32__)
+   // including a system header before Python.h is strongly recommended against by python but we want to be able to compile
+   // #warning should exist in this particular build configuration
+#  warning "including <cmath> before <Python.h> to work around wrong definition of hypot. Be warned that this might break stuff."
+#  include <cmath>
+#endif
+
 #include <Python.h>
 #include <frameobject.h>
 


### PR DESCRIPTION
to work around wrong hypot definiton

Python's `pyconfig.h` defines `hypot` as `_hypot` on `__GNUC__ `+ `_WIN32`
but mingw's `cmath` expects the function to be named `hypot`
so on that particular build configuration we need to include `cmath` before `Python.h`
(and we also issue a warning about that because including system headers before `Python.h`
is strongly recommended against in the python docs)

See:
https://bugs.python.org/issue11566
https://stackoverflow.com/questions/10660524/error-building-boost-1-49-0-with-gcc-4-7-0
http://boost.2283326.n4.nabble.com/Boost-Python-Compile-Error-s-GCC-via-MinGW-w64-td3165793.html#a3166757

This change allows me to compile.
Thus far Python behaves as expected in my project (but I guess there is no sure way to test everything).