### PR TITLE
Fix #75 <complex> may define macro I

### DIFF
--- a/include/pybind11/complex.h
+++ b/include/pybind11/complex.h
@@ -12,6 +12,11 @@
 #include "pybind11.h"
 #include <complex>
 
+/// glibc defines I as a macro which breaks things, e.g., boost template names
+#ifdef I
+#  undef I
+#endif
+
 NAMESPACE_BEGIN(pybind11)
 
 PYBIND11_DECL_FMT(std::complex<float>, "Zf");


### PR DESCRIPTION
Fix #75 as described by undefining the macro `I` from `<complex>` if defined (as in `glibc`).

This seems to be the only include of it.

Ref to [some random version of glibc](https://github.com/andikleen/glibc/blob/b0399147730d478ae45160051a8a0f00f91ef965/math/complex.h#L48-L49).