### PR TITLE
Add get_include function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ MANIFEST
 /.ninja_*
 /*.ninja
 /docs/.build
+*.py[co]
+*.egg-info
+*~
+.DS_Store

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,0 +1,22 @@
+from ._version import version_info, __version__
+
+def get_include():
+    """
+    Return the directory that contains the pybind11 \\*.h header files.
+
+    Extension modules that need to compile against pybind11 should use this
+    function to locate the appropriate include directory.
+
+    Notes
+    -----
+    When using ``distutils``, for example in ``setup.py``.
+    ::
+        import pybind11 as pb
+        ...
+        Extension('extension_name', ...
+        include_dirs=[pb.get_include()])
+        ...
+    """
+    import os
+    return os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                        '..', 'include'))

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -1,0 +1,2 @@
+version_info = (1, 2, 0, 'dev')
+__version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,29 @@
 # Setup script for PyPI; use CMakeFile.txt to build the example application
 
 from setuptools import setup
+import os
+
+here = os.path.abspath(os.path.dirname(__file__))
+name = 'pybind11'
+
+packages = []
+for d, _, _ in os.walk(os.path.join(here, name)):
+    if os.path.exists(os.path.join(d, '__init__.py')):
+        packages.append(d[len(here) + 1:].replace(os.path.sep, '.'))
+
+version_ns = {}
+with open(os.path.join(here, name, '_version.py')) as f:
+        exec(f.read(), {}, version_ns)
 
 setup(
-    name='pybind11',
-    version='1.0',
+    name=name,
+    version=version_ns['__version__'],
     description='Seamless operability between C++11 and Python',
     author='Wenzel Jakob',
     author_email='wenzel@inf.ethz.ch',
     url='https://github.com/wjakob/pybind11',
     download_url='https://github.com/wjakob/pybind11/tarball/v1.0',
-    packages=[],
+    packages=packages,
     license='BSD',
     headers=[
         'include/pybind11/attr.h',


### PR DESCRIPTION
1. This PR adds a `get_include` function to the pybind11 module, which returns the directory that contains the `pybind11/*.h` header files.

    Extension modules that need to compile against pybind11 should use this function to locate the appropriate include directory, in the same way as common packages such as `numpy`. This allows to use pip and setuptools as a build system for extension modules.

    I made an example project that uses pybind11 here: https://github.com/SylvainCorlay/pbtest which shows how we can make pip-installable packages that use pybind11.

2. ~~Besides, I had to change the directory structure so that `get_include` does not need to use paths of the form `foo/bar/../baz` which don't work in certain sandboxed environments.~~

3. Finally, I added a `__version__` to the pybind11 module that is also fetched in `setup.py`, and adopt the semver versioning convention. (So that the current version after this pr is `1.2.0dev`, which is between the current `1.1.0` and `1.2.0`)