### PR TITLE
Add version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ MANIFEST
 /.ninja_*
 /*.ninja
 /docs/.build
+*.py[co]
+*.egg-info
+*~
+.DS_Store

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,0 +1,12 @@
+To release a new version of pybind11:
+
+- Update `_version.py` (set release version, remove 'dev')
+- `git add` and `git commit`.
+- `python setup.py sdist upload`.
+- `python setup.py bdist_wheel upload`.
+- `git tag -a X.X -m 'Release tag comment'`.
+- Update `_version.py` (add 'dev' and increment minor).
+- `git add` and `git commit`. `git push`. `git push --tags`.
+
+The remote for the last `git push --tags` should be the main repository for
+pybind11.

--- a/pybind11/__init__.py
+++ b/pybind11/__init__.py
@@ -1,0 +1,1 @@
+from ._version import version_info, __version__

--- a/pybind11/_version.py
+++ b/pybind11/_version.py
@@ -1,0 +1,2 @@
+version_info = (1, 2, 'dev0')
+__version__ = '.'.join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,17 @@
 # Setup script for PyPI; use CMakeFile.txt to build the example application
 
 from setuptools import setup
+from pybind11 import __version__
 
 setup(
     name='pybind11',
-    version='1.0',
+    version=__version__,
     description='Seamless operability between C++11 and Python',
     author='Wenzel Jakob',
     author_email='wenzel@inf.ethz.ch',
     url='https://github.com/wjakob/pybind11',
     download_url='https://github.com/wjakob/pybind11/tarball/v1.0',
-    packages=[],
+    packages=['pybind11'],
     license='BSD',
     headers=[
         'include/pybind11/attr.h',


### PR DESCRIPTION
Parts of #88 where I add the version info.

Regarding the `get_include` function, I am not adding it here for now. I did not know about the possibility to direrectly add header files under the Python include directory.

Although numpy's `get_include` approach works with development installation, which is an advantage.