### PR TITLE
Fixes and additions for Intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 string(REPLACE "+" "" PYTHONLIBS_VERSION_STRING "+${PYTHONLIBS_VERSION_STRING}")
 find_package(PythonInterp ${PYTHONLIBS_VERSION_STRING} EXACT REQUIRED)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
   CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
   CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_CPP11_FLAG)
 
@@ -57,9 +57,16 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 
     # Check for Link Time Optimization support
+    # (GCC/Clang)
     CHECK_CXX_COMPILER_FLAG("-flto" HAS_LTO_FLAG)
     if (HAS_LTO_FLAG)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+    endif()
+
+    # Intel equivalent to LTO is called IPO
+    CHECK_CXX_COMPILER_FLAG("-ipo" HAS_IPO_FLAG)
+    if (HAS_IPO_FLAG)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ipo")
     endif()
   endif()
 endif()

--- a/include/pybind11/attr.h
+++ b/include/pybind11/attr.h
@@ -277,7 +277,7 @@ template <int Nurse, int Patient> struct process_attribute<keep_alive<Nurse, Pat
 };
 
 /// Ignore that a variable is unused in compiler warnings
-template<class T> void ignore_unused(const T&) { }
+inline void ignore_unused(const int *) { }
 
 /// Recursively iterate over variadic template arguments
 template <typename... Args> struct process_attributes {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -519,8 +519,15 @@ public:
 
     explicit operator type*() { return this->value; }
     explicit operator type&() { return *(this->value); }
-    explicit operator holder_type&() { return holder; }
     explicit operator holder_type*() { return &holder; }
+
+    // Workaround for Intel compiler bug
+    // see pybind11 issue 94
+    #if defined(__ICC) || defined(__INTEL_COMPILER)
+    operator holder_type&() { return holder; }
+    #else
+    explicit operator holder_type&() { return holder; }
+    #endif
 
     static handle cast(const holder_type &src, return_value_policy policy, handle parent) {
         return type_caster_generic::cast(

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -149,7 +149,7 @@ enum class return_value_policy : int {
 
 /// Format strings for basic number types
 template <typename type> struct format_descriptor { };
-#define PYBIND11_DECL_FMT(t, n) template<> struct format_descriptor<t> { static std::string value() { return n; }; };
+#define PYBIND11_DECL_FMT(t, n) template<> struct format_descriptor<t> { static std::string value() { return n; }; }
 PYBIND11_DECL_FMT(int8_t,  "b"); PYBIND11_DECL_FMT(uint8_t,  "B"); PYBIND11_DECL_FMT(int16_t, "h"); PYBIND11_DECL_FMT(uint16_t, "H");
 PYBIND11_DECL_FMT(int32_t, "i"); PYBIND11_DECL_FMT(uint32_t, "I"); PYBIND11_DECL_FMT(int64_t, "q"); PYBIND11_DECL_FMT(uint64_t, "Q");
 PYBIND11_DECL_FMT(float,   "f"); PYBIND11_DECL_FMT(double,   "d"); PYBIND11_DECL_FMT(bool,    "?");

--- a/include/pybind11/operators.h
+++ b/include/pybind11/operators.h
@@ -76,13 +76,13 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_r, B, L
 };                                                                                     \
 inline op_<op_##id, op_l, self_t, self_t> op(const self_t &, const self_t &) {         \
     return op_<op_##id, op_l, self_t, self_t>();                                       \
-};                                                                                     \
+}                                                                                      \
 template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
     return op_<op_##id, op_l, self_t, T>();                                            \
-};                                                                                     \
+}                                                                                      \
 template <typename T> op_<op_##id, op_r, T, self_t> op(const T &, const self_t &) {    \
     return op_<op_##id, op_r, T, self_t>();                                            \
-};
+}
 
 #define PYBIND11_INPLACE_OPERATOR(id, op, expr)                                          \
 template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L, R> { \
@@ -92,7 +92,7 @@ template <typename B, typename L, typename R> struct op_impl<op_##id, op_l, B, L
 };                                                                                     \
 template <typename T> op_<op_##id, op_l, self_t, T> op(const self_t &, const T &) {    \
     return op_<op_##id, op_l, self_t, T>();                                            \
-};
+}
 
 #define PYBIND11_UNARY_OPERATOR(id, op, expr)                                            \
 template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_t> {   \
@@ -102,7 +102,7 @@ template <typename B, typename L> struct op_impl<op_##id, op_u, B, L, undefined_
 };                                                                                     \
 inline op_<op_##id, op_u, self_t, undefined_t> op(const self_t &) {                    \
     return op_<op_##id, op_u, self_t, undefined_t>();                                  \
-};
+}
 
 PYBIND11_BINARY_OPERATOR(sub,       rsub,         operator-,    l - r)
 PYBIND11_BINARY_OPERATOR(add,       radd,         operator+,    l + r)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -18,6 +18,7 @@
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4512) // warning C4512: Assignment operator was implicitly defined as deleted
 #elif defined(__ICC) || defined(__INTEL_COMPILER)
+#  pragma warning(push)
 #  pragma warning(disable:2196)  // warning #2196: routine is both "inline" and "noinline"
 #elif defined(__GNUG__) and !defined(__clang__)
 #  pragma GCC diagnostic push
@@ -1055,6 +1056,8 @@ inline function get_overload(const void *this_ptr, const char *name)  {
 NAMESPACE_END(pybind11)
 
 #if defined(_MSC_VER)
+#  pragma warning(pop)
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
 #  pragma warning(pop)
 #elif defined(__GNUG__) and !defined(__clang__)
 #  pragma GCC diagnostic pop

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -17,6 +17,8 @@
 #  pragma warning(disable: 4996) // warning C4996: The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
 #  pragma warning(disable: 4100) // warning C4100: Unreferenced formal parameter
 #  pragma warning(disable: 4512) // warning C4512: Assignment operator was implicitly defined as deleted
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#  pragma warning(disable:2196)  // warning #2196: routine is both "inline" and "noinline"
 #elif defined(__GNUG__) and !defined(__clang__)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wunused-but-set-parameter"

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -974,7 +974,7 @@ PYBIND11_NOINLINE inline void keep_alive_impl(int Nurse, int Patient, handle arg
 
 NAMESPACE_END(detail)
 
-template <typename... Args> detail::init<Args...> init() { return detail::init<Args...>(); };
+template <typename... Args> detail::init<Args...> init() { return detail::init<Args...>(); }
 
 template <typename InputType, typename OutputType> void implicitly_convertible() {
     auto implicit_caster = [](PyObject *obj, PyTypeObject *type) -> PyObject * {


### PR DESCRIPTION
- Fixes/works around compilation errors and segfaults (Issue #94)
- Suppresses warning about inline/noinline functions
- Adds flag detection to CMake file
- Remove some extra semicolons that generate lots of warnings with higher warning levels (including GCC)