### PR TITLE
Python overloading of virtual functions defined in class template

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1047,7 +1047,7 @@ inline function get_overload(const void *this_ptr, const char *name)  {
         pybind11::gil_scoped_acquire gil; \
         pybind11::function overload = pybind11::get_overload(this, #name); \
         if (overload) \
-            return overload.call(__VA_ARGS__).cast<ret_type>();  }
+            return overload.call(__VA_ARGS__).template cast<ret_type>();  }
 
 #define PYBIND11_OVERLOAD(ret_type, class_name, name, ...) \
     PYBIND11_OVERLOAD_INT(ret_type, class_name, name, __VA_ARGS__) \


### PR DESCRIPTION
This PR fixes #116 

It adds two macros, PYBIND11_TEMPLATE_OVERLOAD and PYBIND11_TEMPLATE_OVERLOAD_PURE that should be used instead of PYBIND11_OVERLOAD and PYBIND11_OVERLOAD_PURE when overriding a virtual function defined in a class template.